### PR TITLE
Switched the events to use method_missing instead of instance_eval to fix

### DIFF
--- a/lib/net/yail.rb
+++ b/lib/net/yail.rb
@@ -598,23 +598,31 @@ class YAIL
     case event.type
       # Ping is important to handle quickly, so it comes first.
       when :incoming_ping
+        event.ensure_values_for [:type, :text]
         handle(event.type, event.text)
 
       when :incoming_numeric
+        event.ensure_values_for [:numeric, :servername, :target, :text]
+	
         # Lovely - I passed in a "nick" - which, according to spec, is NEVER part of a numeric reply
         handle_numeric(event.numeric, event.servername, nil, event.target, event.text)
 
       when :incoming_invite
+        event.ensure_values_for [:type, :fullname, :nick, :channel]
         handle(event.type, event.fullname, event.nick, event.channel)
 
       # Fortunately, the legacy handler for all five "message" types is the same!
       when :incoming_msg, :incoming_ctcp, :incoming_act, :incoming_notice, :incoming_ctcpreply
+        # Ensure that all the required attributes are declared
+        event.ensure_values_for [:type, :from, :text]
+
         # Legacy handling requires merger of target and channel....
         target = event.target if event.pm?
         target = event.channel if !target
 
         # Notices come from server sometimes, so... another merger for legacy fun!
         nick = event.server? ? '' : event.nick
+
         handle(event.type, event.from, nick, target, event.text)
 
       # This is a bit painful for right now - just use some hacks to make it work semi-nicely,
@@ -622,29 +630,37 @@ class YAIL
       #
       # NOTE: text is currently the mode settings ('+b', for instance) - very bad.  TODO: FIX FIX FIX!
       when :incoming_mode
+        event.ensure_values_for [:type, :from, :channel, :text, :targets]
         # Modes can come from the server, so legacy system again regularly sent nil data....
         nick = event.server? ? '' : event.nick
         handle(event.type, event.from, nick, event.channel, event.text, event.targets.join(' '))
 
       when :incoming_topic_change
+        event.ensure_values_for [:type, :fullname, :nick, :channel, :text]
         handle(event.type, event.fullname, event.nick, event.channel, event.text)
 
       when :incoming_join
+        event.ensure_values_for [:type, :fullname, :nick, :channel]
         handle(event.type, event.fullname, event.nick, event.channel)
 
       when :incoming_part
+        event.ensure_values_for [:type, :fullname, :nick, :channel, :text]
         handle(event.type, event.fullname, event.nick, event.channel, event.text)
 
       when :incoming_kick
+        event.ensure_values_for [:type, :fullname, :nick, :channel, :target, :text]
         handle(event.type, event.fullname, event.nick, event.channel, event.target, event.text)
 
       when :incoming_quit
+        event.ensure_values_for [:type, :fullname, :nick, :text]
         handle(event.type, event.fullname, event.nick, event.text)
 
       when :incoming_nick
+        event.ensure_values_for [:type, :fullname, :nick, :text]
         handle(event.type, event.fullname, event.nick, event.text)
 
       when :incoming_error
+        event.ensure_values_for [:type, :text]
         handle(event.type, event.text)
 
       # Unknown line!

--- a/lib/net/yail/event.rb
+++ b/lib/net/yail/event.rb
@@ -68,13 +68,6 @@ class YAIL
       @raw = @data.delete(:raw)
       @msg = @data.delete(:msg)
       @type = @data.delete(:type)
-
-      # Give useful accessors in a hacky but fun way!  I can't decide if I prefer the pain of
-      # using method_missing or the pain of not knowing how to do this without a string eval....
-      for key in @data.keys
-        key = key.to_s
-        self.instance_eval("def #{key}; return @data[:#{key}]; end")
-      end
     end
 
     # Helps us debug
@@ -197,6 +190,12 @@ class YAIL
       end
 
       return event
+    end
+
+    # Prefer method_missing to using instance_eval due to the fact that some of
+    # the callbacks rely on certain attributes being declared.
+    def method_missing(*args,&block)
+      @data[args[0].to_sym]
     end
 
     protected

--- a/lib/net/yail/event.rb
+++ b/lib/net/yail/event.rb
@@ -192,10 +192,23 @@ class YAIL
       return event
     end
 
-    # Prefer method_missing to using instance_eval due to the fact that some of
-    # the callbacks rely on certain attributes being declared.
+    # This method will ensure that each of the given keys have values assigned to them
+    # so that a value missing from the server won't cause a NoMethodError.
+    def ensure_values_for(keys)
+      keys.each do |key|
+        @data[key.to_sym]||=nil
+      end
+    end
+
+    # Define the method missing so that any keys that have been defined in the data
+    # array are accessible through methods of the same name.  This method will throw
+    # a NoMethodError if the key is not defined in the array.
     def method_missing(*args,&block)
-      @data[args[0].to_sym]
+      if @data.has_key?(args[0].to_sym)
+        @data[args[0].to_sym]
+      else
+        super(args,block)
+      end
     end
 
     protected

--- a/tests/mock_irc.rb
+++ b/tests/mock_irc.rb
@@ -102,7 +102,8 @@ class MockIRC
     @nick = nick
 
     unless @logged_in
-      add_output ":#{SERVER} NOTICE #{@nick} :*** You are exempt from user limits. congrats.",
+      add_output "NOTICE AUTH :*** Looking up your hostname",
+                 ":#{SERVER} NOTICE #{@nick} :*** You are exempt from user limits. congrats.",
                  ":#{SERVER} 001 #{@nick} :Welcome to the Fakey-fake Internet Relay Chat Network #{@nick}",
                  ":#{SERVER} 002 #{@nick} :Your host is #{SERVER}[0.0.0.0/6667], running version mock-irc-1.7.7",
                  ":#{SERVER} 003 #{@nick} :This server was created Nov 21 2009 at 21:20:48",

--- a/tests/tc_yail.rb
+++ b/tests/tc_yail.rb
@@ -99,13 +99,14 @@ class YailSessionTest < Test::Unit::TestCase
     wait_for_irc
     assert_equal 1, @msg[:welcome]
     assert_equal 1, @msg[:endofmotd]
-    assert_equal 2, @msg[:notice]
+    assert_equal 3, @msg[:notice]
 
     # Intense notice test - make sure all events were properly translated
-    assert_equal ['fakeirc.org', 'fakeirc.org'], @notices.collect {|n| n[:server]}
-    assert_equal ['', ''], @notices.collect {|n| n[:nick]}
-    assert_equal ['AUTH', 'Bot'], @notices.collect {|n| n[:target]}
+    assert_equal ['fakeirc.org', nil, 'fakeirc.org'], @notices.collect {|n| n[:server]}
+    assert_equal ['', '', ''], @notices.collect {|n| n[:nick]}
+    assert_equal ['AUTH', 'AUTH', 'Bot'], @notices.collect {|n| n[:target]}
     assert_match %r|looking up your host|i, @notices.first[:text]
+    assert_match %r|looking up your host|i, @notices[1][:text]
     assert_match %r|you are exempt|i, @notices.last[:text]
 
     # Test magic methods that set up the bot


### PR DESCRIPTION
Switched the events to use method_missing instead of instance_eval to fix a problem with required attributes.

Basically, I was running into a problem with Quakenet (when just testing against random servers) that it doesn't include the prefix (on at least its NOTICE messages).  However when firing the :incoming_notice it assumes that event.from is there, causing an error.  Using method_missing allows it to ignore this silently and just return nil for anything it doesn't have.  

Ran the tests this time and they all passed.  Connecting to Quakenet worked as well.
