### PR TITLE
Namespace OpenSSL::Buffering properly

### DIFF
--- a/lib/net/yail.rb
+++ b/lib/net/yail.rb
@@ -533,7 +533,7 @@ class YAIL
     return [@socket.gets] unless @ssl
 
     # SSL socket == return all lines available
-    return @socket.readpartial(Buffering::BLOCK_SIZE).split($/).collect {|message| message}
+    return @socket.readpartial(OpenSSL::Buffering::BLOCK_SIZE).split($/).collect {|message| message}
   end
 
   # Reads incoming data - should only be called by io_loop, and only when


### PR DESCRIPTION
SSL connections fail because Ruby can't figure out where BLOCK_SIZE is supposed to come from. Fixed by qualifying Buffering with its parent namespace.
